### PR TITLE
Updated for February 2022 changes.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "No Search For",
-  "version": "3",
+  "version": "4",
   "description": "Remove the 'People also search for' element on google search",
   "content_scripts": [
     {

--- a/root.css
+++ b/root.css
@@ -1,16 +1,4 @@
-/* keeping old changes for where new design is not rolled out */
-.exp-outline {
-  /* don't outline the last clicked search result */
-  border: none !important;
-}
-
-.exp-outline + div > div:nth-child(3) {
-  /* don't display list of suggestions */
-  display: none !important;
-}
-
-/* New changes */
-.IsZvec > div:nth-child(3)[jscontroller] {
+.jtfYYd > div:nth-child(3) > div[jscontroller] {
   /* don't display list of suggestions */
   display: none !important;
 }

--- a/root.css
+++ b/root.css
@@ -1,3 +1,11 @@
+
+/* Dec 2021 changes */
+.IsZvec > div:nth-child(3)[jscontroller] {
+  /* don't display list of suggestions */
+  display: none !important;
+}
+
+/* Feb 2022 changes */
 .jtfYYd > div:nth-child(3) > div[jscontroller] {
   /* don't display list of suggestions */
   display: none !important;

--- a/root.css
+++ b/root.css
@@ -1,12 +1,10 @@
 
 /* Dec 2021 changes */
 .IsZvec > div:nth-child(3)[jscontroller] {
-  /* don't display list of suggestions */
   display: none !important;
 }
 
 /* Feb 2022 changes */
 .jtfYYd > div:nth-child(3) > div[jscontroller] {
-  /* don't display list of suggestions */
   display: none !important;
 }


### PR DESCRIPTION
.IsZvec is replaced with .jtfYYd for main container holding search search results and suggestions.
Also, this is no longer selecting the third child indiscriminately. So erasing of preview text on search results should no longer be a problem.

Keeping or removing old code is debateable. 5 nodes with old selector .IsZvec are still present in DOM so I think removing old implementation is necessary.